### PR TITLE
Add tests to the webpack plugin for the rejectedCss option

### DIFF
--- a/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css/expected/styles-rejected.css
+++ b/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css/expected/styles-rejected.css
@@ -1,0 +1,5 @@
+
+
+.rejected {
+  color: blue;
+}

--- a/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css/src/content.html
+++ b/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css/src/content.html
@@ -1,0 +1,11 @@
+<html>
+
+<head>
+  <title>Purgecss webpack test</title>
+</head>
+
+<body>
+  <div class="preserved"></div>
+</body>
+
+</html>

--- a/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css/src/index.js
+++ b/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css/src/index.js
@@ -1,0 +1,1 @@
+import "./style.css";

--- a/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css/src/style.css
+++ b/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css/src/style.css
@@ -1,0 +1,8 @@
+
+.preserved {
+  color: red;
+}
+
+.rejected {
+  color: blue;
+}

--- a/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css/webpack.config.js
+++ b/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css/webpack.config.js
@@ -1,0 +1,44 @@
+const path = require("path");
+const glob = require("glob");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const PurgecssPlugin = require("../../../src").default;
+
+const PATHS = {
+  src: path.join(__dirname, "src"),
+};
+
+module.exports = {
+  mode: "development",
+  entry: "./src/index.js",
+  context: path.resolve(__dirname),
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        styles: {
+          name: "styles",
+          type: "css/mini-extract",
+          test: /\.css$/,
+          chunks: "all",
+          enforce: true,
+        },
+      },
+    },
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [MiniCssExtractPlugin.loader, "css-loader"],
+      },
+    ],
+  },
+  plugins: [
+    new MiniCssExtractPlugin({
+      filename: "[name].css",
+    }),
+    new PurgecssPlugin({
+      paths: () => glob.sync(`${PATHS.src}/*`),
+      rejectedCss: true,
+    }),
+  ],
+};

--- a/packages/purgecss-webpack-plugin/__tests__/index.test.ts
+++ b/packages/purgecss-webpack-plugin/__tests__/index.test.ts
@@ -38,6 +38,7 @@ describe("Webpack integration", () => {
     "path-and-safelist-functions",
     "simple",
     "simple-with-exclusion",
+    "rejected-css",
   ];
 
   for (const testCase of cases) {


### PR DESCRIPTION
This PR will add a test for the `rejectedCss` option in the webpack plugin